### PR TITLE
Fix inconsistency with ISA call convention

### DIFF
--- a/gcc/gcc/config/riscv/riscv.h
+++ b/gcc/gcc/config/riscv/riscv.h
@@ -892,14 +892,14 @@ typedef struct {
 #endif
 
 #define REGISTER_NAMES						\
-{ "zero","ra",  "sp",  "tp",  "gp",  "t0",  "t1",  "t2",	\
-  "s0",  "s1",  "a0",  "a1",  "a2",  "a3",  "a4",  "a5",	\
-  "a6",  "a7",  "s2",  "s3",  "s4",  "s5",  "s6",  "s7",	\
-  "s8",  "s9",  "s10", "s11", "t3",  "t4",  "t5",  "t6",	\
-  "ft0", "ft1", "ft2", "ft3", "ft4", "ft5", "ft6", "ft7",	\
-  "fs0", "fs1", "fa0", "fa1", "fa2", "fa3", "fa4", "fa5",	\
-  "fa6", "fa7", "fs2", "fs3", "fs4", "fs5", "fs6", "fs7",	\
-  "fs8", "fs9", "fs10","fs11","ft8", "ft9", "ft10","ft11",	\
+{ "zero","ra",  "s0",  "s1",  "s2",  "s3",  "s4",  "s5",	\
+  "s6",  "s7",  "s8",  "s9",  "s10", "s11", "sp",  "tp",	\
+  "v0",  "v1",  "a0",  "a1",  "a2",  "a3",  "a4",  "a5",	\
+  "a6",  "a7",  "t0",  "t1",  "t2",  "t3",  "t4",  "gp",	\
+  "fs0", "fs1", "fs2", "fs3", "fs4", "fs5", "fs6", "fs7",	\
+  "fs8", "fs9", "fs10","fs11","fs12","fs13","fs14","fs15",	\
+  "fv0", "fv1", "fa0", "fa1", "fa2", "fa3", "fa4", "fa5",	\
+  "fa6", "fa7", "ft0", "ft1", "ft2", "ft3", "ft4", "ft5",	\
   "arg", "frame", }
 
 #define ADDITIONAL_REGISTER_NAMES					\


### PR DESCRIPTION
Problem:
--------------
Going through assembly code of riscv-tests there are inconsistencies
between:
- Table 18.2 "RISC-V calling convention register usage" of User Level
ISA 2.0
- Assembly code <==> binary code generated with riscv-gnu-toolchain

Example:
---------------
One example instruction, compiled with the riscv-gnu-toolchain
downloaded and compiled this week:

       00200e13              li    t3,2

The produced binary instruction "00200e13" has rd bits = x28, however
Table 18.2 states that assembly's "t3" is x29.

Possible reason:
-------------------------
Quickly parsing through the riscv-gnu-toolchain git I'm seeing the place
where REGISTER_NAMES is defined and find a very different naming here:

https://github.com/ucb-bar/riscv-gnu-
toolchain/blob/master/gcc/gcc/config/riscv/riscv.h#L898