### PR TITLE
glibc: Undefine ELF_MACHINE_DEBUG_SETUP

### DIFF
--- a/glibc/sysdeps/riscv/dl-machine.h
+++ b/glibc/sysdeps/riscv/dl-machine.h
@@ -78,8 +78,6 @@
 #define ELF_MACHINE_NO_REL 1
 #define ELF_MACHINE_NO_RELA 0
 
-#define ELF_MACHINE_DEBUG_SETUP(l,r)
-
 /* Return nonzero iff ELF header is compatible with the running host.  */
 static inline int __attribute_used__
 elf_machine_matches_host (const ElfW(Ehdr) *ehdr)


### PR DESCRIPTION
Ensure that ld.so follows the preferred canonical behavior, whereby `dl_main()` populates the `DT_DEBUG` entry in the `.dynamic` section with the runtime address of the `r_debug` struct.  GDB relies on `r_debug` to locate the link map when reconstructing the shared library list.

This is documented in `elf/rtld-debugger-interface.txt` in the glibc source tree.  Yet again, MIPS proves itself to be a poor example to emulate, as it is the only architecture that treats `DT_DEBUG` differently.