### PR TITLE
Change a "inline" to "__inline__"

### DIFF
--- a/glibc/sysdeps/riscv/bits/string.h
+++ b/glibc/sysdeps/riscv/bits/string.h
@@ -12,7 +12,7 @@
 
 #if defined(__GNUC__) && !defined(__cplusplus)
 
-static inline unsigned long __libc_detect_null(unsigned long w)
+static __inline__ unsigned long __libc_detect_null(unsigned long w)
 {
   unsigned long mask = 0x7f7f7f7f;
   if (sizeof(long) == 8)


### PR DESCRIPTION
So "inline" isn't complient C, which means strict packages won't build
with it.  This uses "__inline__" instead, which is ANSI C.  This patch
is required to get freetype to build.