### PR TITLE
ftp://mirrors.kernel.org appears to be down

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,7 +7,7 @@ binutils_version := 2.25
 glibc_version := 2.20
 newlib_version := 1.18.0
 
-GNU_MIRROR := ftp://mirrors.kernel.org/gnu
+GNU_MIRROR := http://mirrors.kernel.org/gnu
 gcc_url := $(GNU_MIRROR)/gcc/gcc-$(gcc_version)/gcc-$(gcc_version).tar.gz
 binutils_url := $(GNU_MIRROR)/binutils/binutils-$(binutils_version).tar.gz
 glibc_url := $(GNU_MIRROR)/glibc/glibc-$(glibc_version).tar.gz


### PR DESCRIPTION
This just uses the HTTP mirror instead, which isn't down.