### PR TITLE
Port libsanitizer to RISC-V (again)

### DIFF
--- a/patches/gcc
+++ b/patches/gcc
@@ -337,3 +337,65 @@
    typedef unsigned int __sanitizer___kernel_old_uid_t;
    typedef unsigned int __sanitizer___kernel_old_gid_t;
  #else
+--- original-gcc/libsanitizer/sanitizer_common/sanitizer_linux.cc
++++ gcc/libsanitizer/sanitizer_common/sanitizer_linux.cc
+@@ -93,11 +93,11 @@
+ }
+ 
+ uptr internal_open(const char *filename, int flags) {
+-  return internal_syscall(__NR_open, (uptr)filename, flags);
++  return internal_syscall(__NR_openat, AT_FDCWD, (uptr)filename, flags);
+ }
+ 
+ uptr internal_open(const char *filename, int flags, u32 mode) {
+-  return internal_syscall(__NR_open, (uptr)filename, flags, mode);
++  return internal_syscall(__NR_openat, AT_FDCWD, (uptr)filename, flags, mode);
+ }
+ 
+ uptr OpenFile(const char *filename, bool write) {
+@@ -139,7 +139,7 @@
+ 
+ uptr internal_stat(const char *path, void *buf) {
+ #if SANITIZER_LINUX_USES_64BIT_SYSCALLS
+-  return internal_syscall(__NR_stat, (uptr)path, (uptr)buf);
++  return internal_syscall(__NR_newfstatat, AT_FDCWD, (uptr)path, (uptr)buf, 0);
+ #else
+   struct stat64 buf64;
+   int res = internal_syscall(__NR_stat64, path, &buf64);
+@@ -150,7 +150,7 @@
+ 
+ uptr internal_lstat(const char *path, void *buf) {
+ #if SANITIZER_LINUX_USES_64BIT_SYSCALLS
+-  return internal_syscall(__NR_lstat, (uptr)path, (uptr)buf);
++  return internal_syscall(__NR_newfstatat, AT_FDCWD, (uptr)path, (uptr)buf, AT_SYMLINK_NOFOLLOW);
+ #else
+   struct stat64 buf64;
+   int res = internal_syscall(__NR_lstat64, path, &buf64);
+@@ -178,15 +178,15 @@
+ }
+ 
+ uptr internal_dup2(int oldfd, int newfd) {
+-  return internal_syscall(__NR_dup2, oldfd, newfd);
++  return internal_syscall(__NR_dup3, oldfd, newfd, 0);
+ }
+ 
+ uptr internal_readlink(const char *path, char *buf, uptr bufsize) {
+-  return internal_syscall(__NR_readlink, (uptr)path, (uptr)buf, bufsize);
++  return internal_syscall(__NR_readlinkat, AT_FDCWD, (uptr)path, (uptr)buf, bufsize);
+ }
+ 
+ uptr internal_unlink(const char *path) {
+-  return internal_syscall(__NR_unlink, (uptr)path);
++  return internal_syscall(__NR_unlinkat, AT_FDCWD, (uptr)path);
+ }
+ 
+ uptr internal_sched_yield() {
+@@ -588,7 +588,7 @@
+ }
+ 
+ uptr internal_getdents(fd_t fd, struct linux_dirent *dirp, unsigned int count) {
+-  return internal_syscall(__NR_getdents, fd, (uptr)dirp, count);
++  return internal_syscall(__NR_getdents64, fd, (uptr)dirp, count);
+ }
+ 
+ uptr internal_lseek(fd_t fd, OFF_T offset, int whence) {


### PR DESCRIPTION
So it turns out that the uapi stuff also broke libsanitizer in some
trivial ways -- essentially we need to replace the old version of the
*at syscalls with the new *at version and some flags.  Upstream has
already fixed this, so all I really did is backport part of an
upstream patch that I don't care to track down the exact origin of:

  commit 7d752f28b590bbad13c877c2aa7f5f8de2cdff10
  Author: kcc <kcc@138bc75d-0d04-0410-961f-82ee72b054a4>
  Date:   Thu May 22 07:09:21 2014 +0000

      libsanitizer merge from upstream r209283

      git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@210743 138bc75d-0d04-0410-961f-82ee72b054a4

Note that this will:

* Break on anything that doesn't support uapi.
* Conflict with the patch that I assume will land in GCC-5.0.

Neither of which I think are important -- just don't build
riscv-gnu-toolchain for anything that's not RISC-V, and drop the patch
when you rebase to 5.0.

This is necessary to get Gentoo to build, as it builds libsanitizer.