### PR TITLE
Include <asm/ptrace.h> from <sys/user.h>

### DIFF
--- a/glibc/sysdeps/unix/sysv/linux/riscv/sys/user.h
+++ b/glibc/sysdeps/unix/sysv/linux/riscv/sys/user.h
@@ -1,1 +1,2 @@
-/* This file is not needed, but in practice gdb might try to include it.  */
+/* x86 puts "struct user_regs_struct" in here, this is just a shim. */
+#include <asm/ptrace.h>


### PR DESCRIPTION
x86 puts "struct user_regs_struct" in <sys/user.h>, but that requires
duplicating code between Linux and glibc.  Even though it's just an
ABI-breaking structure, I don't want to do that.

This causes <sys/user.h> to end up defining "struct user_regs_struct"
which helps with compatibility.  It's not a big deal because the
internals of "struct user_regs_struct" still need some #ifdef, but
it's one less line per package...

While not the greatest ports to copy, powerpc and sh do this.  With
the patch Gentoo still builds.